### PR TITLE
Remove Client's intervals and timeouts (#229)

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -124,7 +124,7 @@ class CommandHandler extends AkairoHandler {
          */
         this.commandUtilSweepInterval = commandUtilSweepInterval;
         if (this.commandUtilSweepInterval > 0) {
-            this.client.setInterval(() => this.sweepCommandUtil(), this.commandUtilSweepInterval);
+            setInterval(() => this.sweepCommandUtil(), this.commandUtilSweepInterval).unref();
         }
 
         /**
@@ -722,16 +722,16 @@ class CommandHandler extends AkairoHandler {
 
         if (!this.cooldowns.get(id)[command.id]) {
             this.cooldowns.get(id)[command.id] = {
-                timer: this.client.setTimeout(() => {
+                timer: setTimeout(() => {
                     if (this.cooldowns.get(id)[command.id]) {
-                        this.client.clearTimeout(this.cooldowns.get(id)[command.id].timer);
+                        clearTimeout(this.cooldowns.get(id)[command.id].timer);
                     }
                     this.cooldowns.get(id)[command.id] = null;
 
                     if (!Object.keys(this.cooldowns.get(id)).length) {
                         this.cooldowns.delete(id);
                     }
-                }, time),
+                }, time).unref(),
                 end: endTime,
                 uses: 0
             };


### PR DESCRIPTION
* fix: Usage of the `Id` syntax instead of the `ID` one

* fix: remove Client's intervals and timeouts

* remove unnecessary unref method

* Update CommandHandler.js